### PR TITLE
revert to using single AWS user with all permissions

### DIFF
--- a/archive/frames/management/commands/migrate_s3.py
+++ b/archive/frames/management/commands/migrate_s3.py
@@ -26,9 +26,7 @@ class Command(BaseCommand):
         if options['delete']:
             logging.info(f"Files will be deleted after they are migrated")
         # Overrite the environment variable AWS credentials with one specially made for this copy operation
-        client = get_s3_client(access_key_override=settings.NEW_AWS_ACCESS_KEY_ID,
-                               secret_key_override=settings.NEW_AWS_SECRET_ACCESS_KEY)
-        old_client = get_s3_client()
+        client = get_s3_client()
         frames = Frame.objects.filter(version__migrated=False)
         if options['site'].lower() != 'all':
             frames = frames.filter(SITEID=options['site'].lower())
@@ -58,7 +56,7 @@ class Command(BaseCommand):
                         version.md5 = response['CopyObjectResult']['ETag'].strip('"')
                         version.save()
                         if options['delete']:
-                            old_client.delete_object(**data_params)
+                            client.delete_object(**data_params)
                         num_files_processed += 1
                     else:
                         logging.error(f"S3 Copy of frame {frame.id} version {version.key} failed to receive updated metadata")

--- a/archive/frames/utils.py
+++ b/archive/frames/utils.py
@@ -4,13 +4,9 @@ from django.conf import settings
 
 
 @lru_cache(maxsize=1)
-def get_s3_client(access_key_override=None, secret_key_override=None):
+def get_s3_client():
     config = boto3.session.Config(region_name='us-west-2', signature_version='s3v4')
-    if access_key_override and secret_key_override:
-        return boto3.client('s3', config=config, aws_access_key_id=access_key_override,
-                            aws_secret_access_key=secret_key_override)
-    else:
-        return boto3.client('s3', config=config)
+    return boto3.client('s3', config=config)
 
 
 def remove_dashes_from_keys(dictionary):

--- a/archive/settings.py
+++ b/archive/settings.py
@@ -180,9 +180,6 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 BUCKET = os.getenv('AWS_BUCKET', 'lcogtarchivetest')
 NEW_BUCKET = os.getenv('NEW_AWS_BUCKET', 'newlcogtarchivetest')
 
-NEW_AWS_ACCESS_KEY_ID = os.getenv('NEW_AWS_ACCESS_KEY_ID', '')
-NEW_AWS_SECRET_ACCESS_KEY = os.getenv('NEW_AWS_SECRET_ACCESS_KEY', '')
-
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',


### PR DESCRIPTION
This reverts things back to using a single AWS user account with all permissions. NOTE that once merged into the s3_migration branch, I will no longer be able to test as we have no user account with the proper permissions. Feel free to merge this if this is what you wanted