### PR TITLE
Add docker-compose template to help with production deployment

### DIFF
--- a/archive/settings.py
+++ b/archive/settings.py
@@ -103,7 +103,7 @@ DATABASES = {
         'USER': DB_USER,
         'PASSWORD': DB_PASS,
         'HOST': os.getenv('DB_HOST', '127.0.0.1'),
-        'PORT': '5432',
+        'PORT': os.getenv('DB_PORT', '5432'),
     },
     'replica': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.7'
+
+# This docker-compose file brings up a Science Archive instance pointing to
+# localhost for its connections to a postgres-postgis DB and the Observation Portal. You
+# will want to modify the DB_* environment variables to connect to your db backend,
+# and modify the OAUTH_* environment variables to contain the correct credentials for
+# your Observation Portal oauth Science Archive application. It also currently requires
+# Either an Amazon Web Services (AWS) S3 bucket with credentials, or a local minio bucket
+# with credentials to store and retrieve the data files.
+services:
+    nginx:
+        image: nginx:1.19.0-alpine
+        ports:
+            - 9500:80
+        volumes:
+            - ./nginx.conf:/etc/nginx/conf.d/default.conf
+            - static_volume:/static
+        depends_on:
+            - science_archive
+    science_archive:
+        image: observatorycontrolsystem/science-archive:1.78
+        expose:
+          - "9501"
+        environment:
+          # Note that 172.17.0.1 works for localhost on linux, but for mac you will
+          # need to use `host.docker.internal` instead to point to localhost.
+          - DB_HOST=172.17.0.1
+          - DB_HOST_READER=172.17.0.1
+          - DB_NAME=sciencearchive
+          - DB_USER=postgres
+          - DB_PASS=postgres
+          - SECRET_KEY={ocs_example_science_archive_secret_key}
+          - AWS_ACCESS_KEY_ID={minio_access_key}
+          - AWS_SECRET_ACCESS_KEY={minio_secret}
+          - AWS_DEFAULT_REGION={minio-region}
+          - AWS_BUCKET={ocs-example-bucket}
+          - S3_ENDPOINT_URL={AWS_S3_base_url}
+          - OAUTH_CLIENT_ID={observation_portal_application_client_id}
+          - OAUTH_CLIENT_SECRET={observation_portal_application_client_secret}
+          - OAUTH_TOKEN_URL=http://172.17.0.1:8000/o/token/
+          - OAUTH_PROFILE_URL=http://172.17.0.1:8000/api/profile/
+          - PROCESSED_EXCHANGE_ENABLED=False
+          - OPENTSDB_PYTHON_METRICS_TEST_MODE=True
+        mem_limit: "512m"
+        restart: always
+        volumes:
+          - static_volume:/static
+        command: >
+            sh -c "python manage.py migrate
+            && python manage.py collectstatic --no-input
+            && gunicorn --bind=0.0.0.0:9501 --worker-class=gevent --workers=4 --access-logfile=- --error-logfile=- archive.wsgi:application"
+
+volumes:
+    static_volume:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,33 @@
+upstream science_archive {
+
+    server science_archive:9501;
+
+}
+
+
+server {
+
+
+    listen 80;
+
+
+    location / {
+
+        proxy_pass http://science_archive;
+
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $host;
+
+        proxy_redirect off;
+
+    }
+
+    location /static/ {
+
+        alias /static/;
+
+    }
+
+
+}


### PR DESCRIPTION
This docker compose still requires connection to an S3 bucket, or minio (which I don't explain how to do). Once we refactor the code we will update it to use local filesystem storage by default i think.