### PR TITLE
Add empty Profile when a new user account is created

### DIFF
--- a/archive/authentication/apps.py
+++ b/archive/authentication/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class AuthenticationConfig(AppConfig):
     name = 'archive.authentication'
+
+    def ready(self):
+        import archive.authentication.signals.handlers  # noqa
+        super().ready()

--- a/archive/authentication/signals/handlers.py
+++ b/archive/authentication/signals/handlers.py
@@ -1,0 +1,12 @@
+from django.dispatch import receiver
+from django.db.models.signals import post_save
+from django.contrib.auth.models import User
+
+from archive.authentication.models import Profile
+
+
+@receiver(post_save, sender=User)
+def cb_user_post_save(sender, instance, created, *args, **kwargs):
+    # If a new user is created, ensure it as a profile set
+    if created:
+        Profile.objects.get_or_create(user=instance)

--- a/archive/authentication/test_views.py
+++ b/archive/authentication/test_views.py
@@ -15,7 +15,7 @@ class TestUserView(ReplicationTestCase):
     def setUp(self, post_mock, get_mock):
         self.normal_user = User.objects.create(username='frodo')
         self.normal_user.backend = settings.AUTHENTICATION_BACKENDS[0]
-        Profile.objects.create(user=self.normal_user)
+        Profile.objects.get_or_create(user=self.normal_user)
         AuthProfile.objects.create(user=self.normal_user)
 
     @responses.activate

--- a/archive/authentication/tests.py
+++ b/archive/authentication/tests.py
@@ -16,7 +16,7 @@ class TestRevokeTokenAPI(APITestCase):
     def setUp(self) -> None:
         super(TestRevokeTokenAPI, self).setUp()
         self.user = User.objects.create(username='test_revoke_token_user')
-        Profile.objects.create(user=self.user)
+        Profile.objects.get_or_create(user=self.user)
         AuthProfile.objects.create(user=self.user)
         self.client.force_login(self.user)
 
@@ -41,9 +41,9 @@ class TestAuthentication(ReplicationTestCase):
     def setUp(self, post_mock, get_mock):
         self.admin_user = User.objects.create_superuser('admin', 'admin@lcgot.net', 'password')
         self.normal_user = User.objects.create(username='frodo')
-        Profile.objects.create(user=self.normal_user)
+        Profile.objects.get_or_create(user=self.normal_user)
         AuthProfile.objects.create(user=self.normal_user)
-        Profile.objects.create(user=self.admin_user)
+        Profile.objects.get_or_create(user=self.admin_user)
         AuthProfile.objects.create(user=self.admin_user)
 
     @patch('requests.get')

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -212,7 +212,7 @@ class TestFrameFiltering(ReplicationTestCase):
         self.admin_user.backend = settings.AUTHENTICATION_BACKENDS[0]
         self.normal_user = User.objects.create(username='frodo', password='theone')
         self.normal_user.backend = settings.AUTHENTICATION_BACKENDS[0]
-        Profile(user=self.normal_user, access_token='test', refresh_token='test').save()
+        Profile.objects.update_or_create(user=self.normal_user, defaults={'access_token': 'test', 'refresh_token': 'test'})
         AuthProfile.objects.create(user=self.normal_user)
         self.public_frame = FrameFactory(proposal_id='public', public_date=datetime.datetime(2000, 1, 1, tzinfo=UTC))
         self.proposal_frame = FrameFactory(proposal_id='prop1', public_date=datetime.datetime(2099, 1, 1, tzinfo=UTC))
@@ -285,7 +285,7 @@ class TestQueryFiltering(ReplicationTestCase):
     @responses.activate
     def test_filters_public(self):
         user = User.objects.create(username='frodo', password='theone')
-        Profile.objects.create(user=user)
+        Profile.objects.get_or_create(user=user)
         AuthProfile.objects.create(user=user)
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
         responses.add(
@@ -359,7 +359,7 @@ class TestZipDownload(ReplicationTestCase):
     def setUp(self):
         self.normal_user = User.objects.create(username='frodo', password='theone')
         self.normal_user.backend = settings.AUTHENTICATION_BACKENDS[0]
-        Profile(user=self.normal_user, access_token='test', refresh_token='test').save()
+        Profile.objects.update_or_create(user=self.normal_user, defaults={'access_token': 'test', 'refresh_token': 'test'})
         self.auth_profile = AuthProfile.objects.create(user=self.normal_user, api_token='myApiToken')
         self.public_frame = FrameFactory(proposal_id='public', public_date=datetime.datetime(2000, 1, 1, tzinfo=UTC))
         self.proposal_frame = FrameFactory(proposal_id='prop1', public_date=datetime.datetime(2099, 1, 1, tzinfo=UTC))


### PR DESCRIPTION
This should close the loop on needing a Profile created for each User account to not crash. This will ensure that future user accounts that are created in the observation portal should have a Profile created for them.