### PR TITLE
Do not iterate over the whole queryset - this is inefficient.

### DIFF
--- a/archive/frames/models.py
+++ b/archive/frames/models.py
@@ -154,7 +154,7 @@ class Frame(models.Model):
 
         if self.area:
             ret_dict['area'] = json.loads(self.area.geojson)
-        ret_dict['related_frames'] = [rf.id for rf in self.related_frames.all()]
+        ret_dict['related_frames'] = list(self.related_frames.all().values_list('id', flat=True))
         return ret_dict
 
 class Headers(models.Model):


### PR DESCRIPTION
For BPMs with potentially hundreds of thousands of related frames, it is much better to use values_list() to aggregate in the DB instead of doing it in the Python layer.