### PR TITLE
Add is_staff to profile response

### DIFF
--- a/archive/authentication/serializers.py
+++ b/archive/authentication/serializers.py
@@ -14,7 +14,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('username', 'profile')
+        fields = ('username', 'profile', 'is_staff')
 
 class RevokeTokenResponseSerializer(serializers.Serializer):
     message = serializers.CharField(default='API token revoked.')


### PR DESCRIPTION
We'd like to be able to access this in the science archive client. I have this currently deployed to http://archive-api-dev.lco.gtn