### PR TITLE
Fix public behavior, add configuration type includes filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.3.2
+2023-04-25
+
+Fix public behavior so that logged in users see all of their proposal's data, public or proprietary by default
+Also add include_configuration_type multiple choice filter so that frames can be filtered by multiple configuration types
+
 2.2.4
 2022-04-21
 

--- a/archive/frames/filters.py
+++ b/archive/frames/filters.py
@@ -72,8 +72,8 @@ class FrameFilter(django_filters.FilterSet):
                 user_proposals = self.request.user.profile.proposals
                 if user_proposals:
                     return queryset.filter(proposal_id__in=user_proposals)
-
-            return queryset.exclude(public_date__lt=timezone.now())
+            else:
+                return queryset.exclude(public_date__lt=timezone.now())
         return queryset
 
     class Meta:

--- a/archive/frames/filters.py
+++ b/archive/frames/filters.py
@@ -45,6 +45,11 @@ class FrameFilter(django_filters.FilterSet):
         label='Exclude Configuration Types',
         exclude=True
     )
+    include_configuration_type = django_filters.MultipleChoiceFilter(
+        field_name='configuration_type',
+        choices=get_configuration_type_tuples(),
+        label='Include Configuration Types',
+    )
     intersects = django_filters.CharFilter(method='intersects_filter')
 
     def covers_filter(self, queryset, name, value):

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -299,20 +299,40 @@ class TestQueryFiltering(ReplicationTestCase):
             content_type='application/json'
         )
         self.client.force_login(user)
-        proposal_frame = FrameFactory(public_date=datetime.datetime(2999, 1, 1, tzinfo=UTC), proposal_id='prop1')
+        proposal_proprietary_frame = FrameFactory(public_date=datetime.datetime(2999, 1, 1, tzinfo=UTC), proposal_id='prop1')
+        proposal_public_frame = FrameFactory(public_date=datetime.datetime(1992, 11, 14, tzinfo=UTC), proposal_id='prop1')
         public_frame = PublicFrameFactory()
 
+        # If public=false, then a logged in user should see all of their own data, proprietary or not
         for false_string in ['false', 'False', '0']:
             response = self.client.get(reverse('frame-list') + '?public={}'.format(false_string))
-            self.assertContains(response, proposal_frame.basename)
+            self.assertContains(response, proposal_proprietary_frame.basename)
+            self.assertContains(response, proposal_public_frame.basename)
             self.assertNotContains(response, public_frame.basename)
+
+        # If public=true, then a logged in user should see all their data + all public data
+        for true_string in ['true', 'True', '1']:
+            response = self.client.get(reverse('frame-list') + '?public={}'.format(true_string))
+            self.assertContains(response, proposal_proprietary_frame.basename)
+            self.assertContains(response, proposal_public_frame.basename)
+            self.assertContains(response, public_frame.basename)
 
         self.client.logout()
 
+        # If public=false, an anonymous user shouldn't see anything
         for false_string in ['false', 'False', '0']:
             response = self.client.get(reverse('frame-list') + '?public={}'.format(false_string))
-            self.assertNotContains(response, proposal_frame.basename)
+            self.assertNotContains(response, proposal_proprietary_frame.basename)
+            self.assertNotContains(response, proposal_public_frame.basename)
             self.assertNotContains(response, public_frame.basename)
+
+        # If public=true an anonymous user should only see publicly available data
+        for true_string in ['true', 'True', '1']:
+            response = self.client.get(reverse('frame-list') + '?public={}'.format(true_string))
+            self.assertNotContains(response, proposal_proprietary_frame.basename)
+            self.assertContains(response, proposal_public_frame.basename)
+            self.assertContains(response, public_frame.basename)
+
 
     def test_area_covers(self):
         frame = PublicFrameFactory.create(

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -316,6 +316,12 @@ class TestQueryFiltering(ReplicationTestCase):
             self.assertContains(response, proposal_proprietary_frame.basename)
             self.assertContains(response, proposal_public_frame.basename)
             self.assertContains(response, public_frame.basename)
+        
+        # If public not specified, then show everything
+        response = self.client.get(reverse('frame-list'))
+        self.assertContains(response, proposal_proprietary_frame.basename)
+        self.assertContains(response, proposal_public_frame.basename)
+        self.assertContains(response, public_frame.basename)
 
         self.client.logout()
 
@@ -332,6 +338,12 @@ class TestQueryFiltering(ReplicationTestCase):
             self.assertNotContains(response, proposal_proprietary_frame.basename)
             self.assertContains(response, proposal_public_frame.basename)
             self.assertContains(response, public_frame.basename)
+
+        # If public not specified, anonymous users should still only see public data
+        response = self.client.get(reverse('frame-list'))
+        self.assertNotContains(response, proposal_proprietary_frame.basename)
+        self.assertContains(response, proposal_public_frame.basename)
+        self.assertContains(response, public_frame.basename)
 
 
     def test_area_covers(self):

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -301,6 +301,7 @@ class TestQueryFiltering(ReplicationTestCase):
         self.client.force_login(user)
         proposal_proprietary_frame = FrameFactory(public_date=datetime.datetime(2999, 1, 1, tzinfo=UTC), proposal_id='prop1')
         proposal_public_frame = FrameFactory(public_date=datetime.datetime(1992, 11, 14, tzinfo=UTC), proposal_id='prop1')
+        non_proposal_proprietary_frame = FrameFactory(public_date=datetime.datetime(2999, 1, 1, tzinfo=UTC), proposal_id='prop2')
         public_frame = PublicFrameFactory()
 
         # If public=false, then a logged in user should see all of their own data, proprietary or not
@@ -309,6 +310,7 @@ class TestQueryFiltering(ReplicationTestCase):
             self.assertContains(response, proposal_proprietary_frame.basename)
             self.assertContains(response, proposal_public_frame.basename)
             self.assertNotContains(response, public_frame.basename)
+            self.assertNotContains(response, non_proposal_proprietary_frame)
 
         # If public=true, then a logged in user should see all their data + all public data
         for true_string in ['true', 'True', '1']:
@@ -316,12 +318,14 @@ class TestQueryFiltering(ReplicationTestCase):
             self.assertContains(response, proposal_proprietary_frame.basename)
             self.assertContains(response, proposal_public_frame.basename)
             self.assertContains(response, public_frame.basename)
-        
+            self.assertNotContains(response, non_proposal_proprietary_frame)
+
         # If public not specified, then show everything
         response = self.client.get(reverse('frame-list'))
         self.assertContains(response, proposal_proprietary_frame.basename)
         self.assertContains(response, proposal_public_frame.basename)
         self.assertContains(response, public_frame.basename)
+        self.assertNotContains(response, non_proposal_proprietary_frame)
 
         self.client.logout()
 
@@ -338,12 +342,14 @@ class TestQueryFiltering(ReplicationTestCase):
             self.assertNotContains(response, proposal_proprietary_frame.basename)
             self.assertContains(response, proposal_public_frame.basename)
             self.assertContains(response, public_frame.basename)
+            self.assertNotContains(response, non_proposal_proprietary_frame)
 
         # If public not specified, anonymous users should still only see public data
         response = self.client.get(reverse('frame-list'))
         self.assertNotContains(response, proposal_proprietary_frame.basename)
         self.assertContains(response, proposal_public_frame.basename)
         self.assertContains(response, public_frame.basename)
+        self.assertNotContains(response, non_proposal_proprietary_frame)
 
 
     def test_area_covers(self):


### PR DESCRIPTION
This is to enable us to provide the following behavior. I think I covered all cases in the updated tests.

* User is logged in, public not checked
    * See ALL data from their proposals, regardless of if it is old and now public*
* User is logged in, public checked 
    * See all public data* and data from their proposals
* User not logged in, public checked
    * See just public data*
* Public Data
    * Actions:
        * Add “view only science data” checkbox (checked by default), which will only include all of the following OBSTYPEs:
EXPOSE, TARGET, SPECTRUM, CATALOG, OBJECT
