### PR TITLE
Fix to post to archive queue whenever Frame object is updated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.5.2
+2024-09-16
+Fix for posting payloads to FITS queue when thumbnail arrives before FITS image
+
 2.5.1
 2024-06-03
 Fix for /frames/ ordering when filtering out frames with empty version_sets

--- a/archive/frames/serializers.py
+++ b/archive/frames/serializers.py
@@ -104,12 +104,12 @@ class FrameSerializer(serializers.ModelSerializer):
         # If there is no version data, don't post this to the archived queue
         if version_data:
             try:
+                post_to_archived_queue(archived_queue_payload(queue_data, frame=frame))
+            except Exception:
                 logger_tags = {'tags': {
                 'filename': '{}{}'.format(queue_data.get('basename'), version_data[0].get('extension')),
                 'request_id': queue_data.get('request_id')
                 }}
-                post_to_archived_queue(archived_queue_payload(queue_data, frame=frame))
-            except Exception:
                 logger.exception('Failed to post frame to archived queue', extra=logger_tags)
         return frame
 

--- a/archive/frames/serializers.py
+++ b/archive/frames/serializers.py
@@ -1,10 +1,15 @@
 import json
+import copy
+import logging
+
 from rest_framework import serializers
 from archive.frames.models import Frame, Version, Headers, Thumbnail
-from archive.frames.utils import get_configuration_type_tuples
+from archive.frames.utils import get_configuration_type_tuples, post_to_archived_queue, archived_queue_payload
 from django.contrib.gis.geos import GEOSGeometry
 from django.db import transaction
 from django.conf import settings
+
+logger = logging.getLogger()
 
 
 class ZipSerializer(serializers.Serializer):
@@ -87,6 +92,7 @@ class FrameSerializer(serializers.ModelSerializer):
         # }
 
     def create(self, validated_data):
+        queue_data = copy.deepcopy(validated_data)
         version_data = validated_data.pop('version_set') if 'version_set' in validated_data else {}
         header_data = validated_data.pop('headers')
         related_frames = validated_data.pop('related_frame_filenames')
@@ -95,6 +101,16 @@ class FrameSerializer(serializers.ModelSerializer):
             self.create_or_update_versions(frame, version_data)
             self.create_or_update_header(frame, header_data)
             self.create_related_frames(frame, related_frames)
+        # If there is no version data, don't post this to the archived queue
+        if version_data:
+            try:
+                logger_tags = {'tags': {
+                'filename': '{}{}'.format(queue_data.get('basename'), version_data[0].get('extension')),
+                'request_id': queue_data.get('request_id')
+                }}
+                post_to_archived_queue(archived_queue_payload(queue_data, frame=frame))
+            except Exception:
+                logger.exception('Failed to post frame to archived queue', extra=logger_tags)
         return frame
 
     def create_or_update_frame(self, data):

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -936,6 +936,9 @@ class TestThumbnailPost(ReplicationTestCase):
             reverse('frame-list'), json.dumps(self.single_frame_payload), content_type='application/json'
         )
         self.assertTrue(Frame.objects.get(basename=self.single_thumbnail_payload['frame_basename']).version_set.exists())
+        # make sure we call to enqueue the message to the FITS exchange
+        self.mock_archive_fits_publish.assert_called_once()
+
 
     def test_thumbnail_post_with_no_size(self):
         del self.single_thumbnail_payload['size']

--- a/archive/frames/utils.py
+++ b/archive/frames/utils.py
@@ -31,11 +31,11 @@ def get_file_store_path(filename, file_metadata):
     return data_file.get_filestore_path()
 
 
-def archived_queue_payload(dictionary, frame):
-    new_dictionary = dictionary.get('headers').copy()
-    new_dictionary['area'] = dictionary.get('area')
-    new_dictionary['basename'] = dictionary.get('basename')
-    new_dictionary['version_set'] = dictionary.get('version_set')
+def archived_queue_payload(validated_data: dict, frame):
+    new_dictionary = validated_data.get('headers').copy()
+    new_dictionary['area'] = validated_data.get('area')
+    new_dictionary['basename'] = validated_data.get('basename')
+    new_dictionary['version_set'] = validated_data.get('version_set')
     new_dictionary['filename'] = frame.filename
     new_dictionary['frameid'] = frame.id
     return new_dictionary

--- a/archive/frames/views.py
+++ b/archive/frames/views.py
@@ -6,8 +6,7 @@ from archive.frames.serializers import (
     HeadersSerializer, AggregateQueryParamsSeralizer,
 )
 from archive.frames.utils import (
-    build_nginx_zip_text, post_to_archived_queue,
-    archived_queue_payload, get_file_store_path,
+    build_nginx_zip_text, get_file_store_path,
     aggregate_frames_sql, get_cached_frames_aggregates
 
 )

--- a/archive/frames/views.py
+++ b/archive/frames/views.py
@@ -113,10 +113,6 @@ class FrameViewSet(viewsets.ModelViewSet):
             frame = frame_serializer.save()
             logger_tags['tags']['id'] = frame.id
             logger.info('Created frame', extra=logger_tags)
-            try:
-                post_to_archived_queue(archived_queue_payload(dictionary=request.data, frame=frame))
-            except Exception:
-                logger.exception('Failed to post frame to archived queue', extra=logger_tags)
             logger.info('Request to process frame succeeded', extra=logger_tags)
             return Response(frame_serializer.data, status=status.HTTP_201_CREATED)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "science-archive"
-version = "2.5.1"
+version = "2.5.2"
 description = ""
 authors = ["Jashandeep Sohi <jsohi@lco.global>"]
 readme = "README.md"


### PR DESCRIPTION
Prior to this, the archive queue post would only happen on frame creation. This becomes an issue if a thumbnail makes it to the archive before the FITS file - we cannot post to queue consumers until after the FITS image is ingested, so make sure we do that in the serializer rather than the view.