### PR TITLE
Various reliability fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.5.5
+2024-10-15
+Construct the queue filename from the version_set within the request body sent by the ingester lib, rather than querying it from the newly created frame object.
+
+Add include_related_frames query param for frames queries. This defaults to true if not set to preserve API compatibility, but can be turned off by setting ?include_related_frames=false.
+
 2.5.4
 2024-09-17
 Make sure we handle files that don't have an area associated with them when sending to the FITS queue

--- a/archive/frames/models.py
+++ b/archive/frames/models.py
@@ -133,7 +133,7 @@ class Frame(models.Model):
             archive_settings.PUBLIC_DATE_KEY: self.public_date,
         }
 
-    def as_dict(self, include_thumbnails=False):
+    def as_dict(self, include_thumbnails=False, include_related_frames=False):
         ret_dict = model_to_dict(self, exclude=('related_frames', 'area'))
         ret_dict['version_set'] = [v.as_dict() for v in self.version_set.all()]
         ret_dict['url'] = self.url if self.version_set.exists() else None
@@ -158,7 +158,10 @@ class Frame(models.Model):
 
         if self.area:
             ret_dict['area'] = json.loads(self.area.geojson)
-        ret_dict['related_frames'] = list(self.related_frames.all().values_list('id', flat=True))
+        if include_thumbnails:
+            ret_dict['thumbnails'] = [t.as_dict() for t in Thumbnail.objects.filter(frame=self)]
+        if include_related_frames:
+            ret_dict['related_frames'] = list(self.related_frames.all().values_list('id', flat=True))
         return ret_dict
 
 

--- a/archive/frames/serializers.py
+++ b/archive/frames/serializers.py
@@ -101,6 +101,8 @@ class FrameSerializer(serializers.ModelSerializer):
             self.create_or_update_versions(frame, version_data)
             self.create_or_update_header(frame, header_data)
             self.create_related_frames(frame, related_frames)
+            # Make sure we refresh the frame from the primary db to avoid any replication lag
+            frame.refresh_from_db(using='default')
         # If there is no version data, don't post this to the archived queue
         if version_data:
             try:

--- a/archive/frames/serializers.py
+++ b/archive/frames/serializers.py
@@ -101,8 +101,6 @@ class FrameSerializer(serializers.ModelSerializer):
             self.create_or_update_versions(frame, version_data)
             self.create_or_update_header(frame, header_data)
             self.create_related_frames(frame, related_frames)
-            # Make sure we refresh the frame from the primary db to avoid any replication lag
-            frame.refresh_from_db(using='default')
         # If there is no version data, don't post this to the archived queue
         if version_data:
             try:

--- a/archive/frames/utils.py
+++ b/archive/frames/utils.py
@@ -36,7 +36,12 @@ def archived_queue_payload(validated_data: dict, frame):
     new_dictionary['area'] = validated_data.get('area').json if validated_data.get('area') else None
     new_dictionary['basename'] = validated_data.get('basename')
     new_dictionary['version_set'] = validated_data.get('version_set')
-    new_dictionary['filename'] = frame.filename
+    # construct filename from version_set
+    try:
+        filename =  ''.join([validated_data.get('basename'), validated_data.get('version_set')[0].get('extension')])
+    except Exception:
+        filename = ''
+    new_dictionary['filename'] = filename
     new_dictionary['frameid'] = frame.id
     return new_dictionary
 

--- a/archive/frames/views.py
+++ b/archive/frames/views.py
@@ -69,9 +69,11 @@ class FrameViewSet(viewsets.ModelViewSet):
         queryset = (
             Frame.objects.exclude(observation_date=None)
             .prefetch_related('version_set')
-            .prefetch_related(Prefetch('related_frames', queryset=Frame.objects.all().only('id')))
             .prefetch_related('thumbnails')
         )
+        # Only prefetch related frames if we're including them in the response
+        if self.request.query_params.get('include_related_frames', '').lower() != 'false':
+            queryset = queryset.prefetch_related(Prefetch('related_frames', queryset=Frame.objects.all().only('id')))
         if self.request.user.is_superuser:
             return queryset
         elif self.request.user.is_authenticated:
@@ -84,16 +86,25 @@ class FrameViewSet(viewsets.ModelViewSet):
 
     # These two method overrides just force the use of the as_dict method for serialization for list and detail endpoints
     def list(self, request, *args, **kwargs):
+        # TODO: Default to not include related frames once we've announced it to users
+        include_related_frames = True
+        if request.query_params.get('include_related_frames', '').lower() == 'false':
+            include_related_frames = False
+        include_thumbnails = True if request.query_params.get('include_thumbnails', '').lower() == 'true' else False
+
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
-        include_thumbnails = True if request.query_params.get('include_thumbnails', '').lower() == 'true' else False
-        json_models = [model.as_dict(include_thumbnails) for model in page]
+        json_models = [model.as_dict(include_thumbnails, include_related_frames) for model in page]
         json_models = [model for model in json_models if model['version_set']]  # Filter out frames with no versions
         return self.get_paginated_response(json_models)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
-        return Response(instance.as_dict())
+        include_thumbnails = True if request.query_params.get('include_thumbnails', '').lower() == 'true' else False
+        include_related_frames = True
+        if request.query_params.get('include_related_frames', '').lower() == 'false':
+            include_related_frames = False
+        return Response(instance.as_dict(include_thumbnails, include_related_frames))
 
     def create(self, request):
         basename = request.data.get('basename')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "science-archive"
-version = "2.5.4"
+version = "2.5.5"
 description = ""
 authors = ["Jashandeep Sohi <jsohi@lco.global>"]
 readme = "README.md"


### PR DESCRIPTION
* Construct the queue filename from the version_set within the request body sent by the ingester lib, rather than querying it from the newly created frame object. There is sometimes a race condition that causes the version_set on the Frame object to be None shortly after it's created. This seems to be a function of DB load.
* Add include_related_frames query param for frames queries. This defaults to true if not set to preserve API compatibility, but can be turned off by setting `?include_related_frames=false`. This is to reduce the load on the service and database from repeated queries to frames that have many thousands of related frames that take a long time to fetch and serialize.