### PR TITLE
Update pagination to support cursor pagination as an option, and to o…

### DIFF
--- a/archive/frames/pagination.py
+++ b/archive/frames/pagination.py
@@ -1,14 +1,27 @@
-from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.pagination import LimitOffsetPagination, CursorPagination
 from django.conf import settings
 from django.db import connections, transaction, OperationalError, InternalError
+from django.utils import dateparse
 
+from datetime import timedelta
 import sys
 import logging
 logger = logging.getLogger(__name__)
 
+
+class CustomCursorPagination(CursorPagination):
+    page_size_query_param='limit'
+    page_size = settings.PAGINATION_DEFAULT_LIMIT
+    max_page_size = settings.PAGINATION_MAX_LIMIT
+
+
 class LimitedLimitOffsetPagination(LimitOffsetPagination):
     default_limit = settings.PAGINATION_DEFAULT_LIMIT
     max_limit = settings.PAGINATION_MAX_LIMIT
+
+    def __init__(self):
+        self.small_query = False
+        super().__init__()
 
     def get_count(self, queryset):
         """
@@ -17,21 +30,22 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
          - https://gist.github.com/safar/3bbf96678f3e479b6cb683083d35cb4d
          - https://medium.com/@hakibenita/optimizing-django-admin-paginator-53c4eb6bfca3
         Overrides the count method of QuerySet objects to avoid timeouts.
-        - Try to get the real count limiting the queryset execution time to 5000 ms.
-        - If count takes longer than 5000 ms the database kills the query and raises OperationError. In that case,
+        - Try to get the real count limiting the queryset execution time to 5000 ms if this is a "small" query.
+        - If large query or count takes longer than 5000 ms the database kills the query and raises OperationError. In that case,
         get an estimate instead of actual count when not filtered (this estimate can be stale and hence not fit for
         situations where the count of objects actually matter).
         - If any other exception occured fall back to no count (large number returned).
         """
         self.count_estimated = False
-        try:
-            with transaction.atomic(using='replica'), connections['replica'].cursor() as cursor:
-                # Limit to 5000 ms
-                cursor.execute('SET LOCAL statement_timeout TO 5000;')
-                return super().get_count(queryset)
-        except (OperationalError, InternalError):
-            logger.warning("Getting the count timed out after 5 seconds")
-
+        # Only attempt to get the real count if we have already determined this is a "small" query
+        if self.small_query:
+            try:
+                with transaction.atomic(using='replica'), connections['replica'].cursor() as cursor:
+                    # Limit to 5000 ms
+                    cursor.execute('SET LOCAL statement_timeout TO 5000;')
+                    return super().get_count(queryset)
+            except (OperationalError, InternalError):
+                logger.warning("Getting the count timed out after 5 seconds")
 
         self.count_estimated = True
         if not queryset.query.where:
@@ -63,6 +77,24 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
                 logger.warning("Failed to estimate count", exc_info=e)
 
         return sys.maxsize
+
+    def paginate_queryset(self, queryset, request, view=None):
+        # If certain conditions are met, this is a "small" query and we can attempt a real count
+        query_params = dict(request.query_params)
+        # If these indexed fields are in the query params, query should be small and bounded so allow full count
+        # Also have a fallback 'force_count' param to force it to attempt the full count
+        if 'request_id' in query_params or 'observation_id' in query_params or 'force_count' in query_params:
+            self.small_query = True
+        elif 'start' in query_params and 'end' in query_params:
+            range = dateparse.parse_datetime(request.query_params.get('end')) - dateparse.parse_datetime(request.query_params.get('start'))
+            # Allow 1 week of querys with no other params
+            if range <= timedelta(days=7):
+                self.small_query = True
+            # Or up to 2 months of querys with some other bounding params
+            elif range <= timedelta(weeks=9) and any(field in query_params for field in ['proposal_id', 'target_name_exact', 'basename_exact']):
+                self.small_query = True
+
+        return super().paginate_queryset(queryset, request, view)
 
     def get_paginated_response(self, data):
         resp = super().get_paginated_response(data)

--- a/archive/frames/views.py
+++ b/archive/frames/views.py
@@ -14,6 +14,7 @@ from archive.frames.permissions import AdminOrReadOnly
 from archive.frames.filters import FrameFilter, ThumbnailFilter
 
 from archive.doc_examples import EXAMPLE_RESPONSES, QUERY_PARAMETERS
+from archive.frames.pagination import LimitedLimitOffsetPagination, CustomCursorPagination
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAdminUser
@@ -46,7 +47,29 @@ from ocs_authentication.auth_profile.models import AuthProfile
 logger = logging.getLogger()
 
 
-class FrameViewSet(viewsets.ModelViewSet):
+class SelectablePaginationMixin:
+    def get_pagination_class(self):
+        # Allow users to specify cursor pagination for faster queries
+        pagination_style = self.request.query_params.get('pagination_style')
+        if pagination_style == 'cursor':
+            return CustomCursorPagination
+        else:
+            return LimitedLimitOffsetPagination
+
+    @property
+    def paginator(self):
+        if not hasattr(self, '_paginator'):
+            pagination_class = self.get_pagination_class()
+            if pagination_class is None:
+                return None
+            self._paginator = pagination_class()
+            return self._paginator
+        else:
+            return self._paginator
+
+
+
+class FrameViewSet(SelectablePaginationMixin, viewsets.ModelViewSet):
     permission_classes = (AdminOrReadOnly,)
     schema = ScienceArchiveSchema(tags=['Frames'])
     serializer_class = FrameSerializer
@@ -57,6 +80,7 @@ class FrameViewSet(viewsets.ModelViewSet):
     filter_class = FrameFilter
     ordering_fields = ('id', 'basename', 'observation_date', 'primary_optical_element', 'configuration_type',
                        'proposal_id', 'instrument_id', 'target_name', 'reduction_level', 'exposure_time')
+    ordering = ['-observation_date']
 
     def get_queryset(self):
         """
@@ -94,9 +118,12 @@ class FrameViewSet(viewsets.ModelViewSet):
 
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
-        json_models = [model.as_dict(include_thumbnails, include_related_frames) for model in page]
-        json_models = [model for model in json_models if model['version_set']]  # Filter out frames with no versions
-        return self.get_paginated_response(json_models)
+        if page is not None:
+            json_models = [model.as_dict(include_thumbnails, include_related_frames) for model in page]
+            json_models = [model for model in json_models if model['version_set']]  # Filter out frames with no versions
+            return self.get_paginated_response(json_models)
+        else:
+            return Response(self.get_serializer(queryset, many=True).data)
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()


### PR DESCRIPTION
…nly perform full count if query is deemed small

I made up some rules for a "small" query by experimenting on prod to see what would return within ~1second and what seems like a useful set to have the real count on. I.e. most users will search for their specific observation/request and want to get the real count there, or searching over a small time period or median time period + some other filters seems reasonable.

Also made the cursor paginator available if the query param `pagination_style=cursor` is present. So we can experiment with switching over our internal services to using cursor pagination.