### PR TITLE
Fix for not allowing offsets with estimated count queries

### DIFF
--- a/archive/frames/pagination.py
+++ b/archive/frames/pagination.py
@@ -110,8 +110,13 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
         else:
             self.force_count = False
             self.small_query = False
-
-        return super().paginate_queryset(queryset, request, view)
+        result = super().paginate_queryset(queryset, request, view)
+        # If the count was estimated and we have an offset, then correct the results!
+        # This is needed because the base code returns an empty list if offset > count
+        if self.count_estimated and (self.count == 0 or self.offset > self.count):
+            return list(queryset[self.offset:self.offset + self.limit])
+        else:
+            return result
 
     def get_paginated_response(self, data):
         resp = super().get_paginated_response(data)


### PR DESCRIPTION
Science Support found a bug in the current science archive client - offset queries were broken due to [this shortcircuit in the base code](https://github.com/encode/django-rest-framework/blob/main/rest_framework/pagination.py#L399). This patch basically ignores the shortcircuit and still attempts to return results when the count is estimated and offset is used. 

Long term I would like to move the science archive client to using cursor queries when it knows the count will be estimated, but as long as we allow limitoffset as an option we should err on providing results with an offset even when the count is estimated.