### PR TITLE
Add middleware to restrict large offsets and limits for unauthenticat…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.7.5
+2026-07-20
+Add in unauthenticated limit/offset limits to GET API requests
+
 2.7.4
 2026-05-08
 Update dependencies to latest, supporting python 3.12+ and django6

--- a/archive/authentication/middleware.py
+++ b/archive/authentication/middleware.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.conf import settings
 from django.http import HttpResponseBadRequest
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.request import Request
+
+logger = logging.getLogger(__name__)
 
 
 class RemoteUserLogMiddleware(object):
@@ -64,5 +68,9 @@ class DRFTokenAuthMiddleware(object):
                 if user_auth:
                     request.user = user_auth[0]
             except Exception:
-                pass
+                # Mask the token: it's a live credential, so only log a short prefix
+                # to allow correlation/debugging without leaking a replayable secret.
+                token = request.headers.get('Authorization', '').split(' ', 1)[-1]
+                masked_token = f'{token[:6]}...' if token else '(none)'
+                logger.warning('DRFTokenAuthMiddleware: Failed to authenticate with token %s', masked_token, exc_info=True)
         return self.get_response(request)

--- a/archive/authentication/middleware.py
+++ b/archive/authentication/middleware.py
@@ -7,9 +7,7 @@ from rest_framework.request import Request
 class RemoteUserLogMiddleware(object):
     ''' This Middleware sets request.META['REMOTE_USER'] to the authenticated username (or 'anonymous')
 
-        Gunicorn logs the WSGI environ's REMOTE_USER via the %(u)s access log format variable.
-        Since request.META is the same dict as the WSGI environ, setting it here makes the
-        username available to Gunicorn's access logger.
+        It can be added to the gunicorn access log with the token: %({remote_user}e)s
 
         It should be placed after Authentication middleware (and DRFTokenAuthMiddleware) so that
         request.user is populated by the time this runs.

--- a/archive/authentication/middleware.py
+++ b/archive/authentication/middleware.py
@@ -1,0 +1,70 @@
+from django.conf import settings
+from django.http import HttpResponseBadRequest
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.request import Request
+
+
+class RemoteUserLogMiddleware(object):
+    ''' This Middleware sets request.META['REMOTE_USER'] to the authenticated username (or 'anonymous')
+
+        Gunicorn logs the WSGI environ's REMOTE_USER via the %(u)s access log format variable.
+        Since request.META is the same dict as the WSGI environ, setting it here makes the
+        username available to Gunicorn's access logger.
+
+        It should be placed after Authentication middleware (and DRFTokenAuthMiddleware) so that
+        request.user is populated by the time this runs.
+    '''
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            username = request.user.username or 'anonymous'
+        except AttributeError:
+            username = 'anonymous'
+
+        request.META['REMOTE_USER'] = username
+
+        return self.get_response(request)
+
+
+class LimitAnonymousAccessMiddleware(object):
+    ''' This Middleware blocks unauthenticated GET requests with large limits and offsets
+    '''
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # If this is an unauthenticated GET request, check the offset and limit and block if theyre too large
+        if request.method == 'GET' and not request.user.is_authenticated:
+            offset = request.GET.get('offset')
+            if offset and offset.isdigit() and int(offset) > settings.MAX_UNAUTHENTICATED_OFFSET:
+                return HttpResponseBadRequest("Large offset not allowed for anonymous users.")
+
+            limit = request.GET.get('limit')
+            if limit and limit.isdigit() and int(limit) > settings.MAX_UNAUTHENTICATED_LIMIT:
+                return HttpResponseBadRequest("Large limit not allowed for anonymous users.")
+
+        return self.get_response(request)
+
+
+class DRFTokenAuthMiddleware(object):
+    ''' This Middleware detects if an API Token is provided and authenticates the request.user with that Token
+    
+        It should be placed after Authentication middleware, and before middleware that uses the request.user
+    '''
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Check if this is a Token Auth request based on the Auth header having `Token` in it.
+        if request.method == 'GET' and request.headers.get('Authorization', '').startswith('Token'):
+            drf_request = Request(request)
+            try:
+                user_auth = TokenAuthentication().authenticate(drf_request)
+                # Set the request.user field if we successfully authenticate with TokenAuthentication
+                if user_auth:
+                    request.user = user_auth[0]
+            except Exception:
+                pass
+        return self.get_response(request)

--- a/archive/authentication/middleware.py
+++ b/archive/authentication/middleware.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 from django.http import HttpResponseBadRequest
-from rest_framework.authentication import TokenAuthentication
+from ocs_authentication.backends import OCSTokenAuthentication
 from rest_framework.request import Request
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class DRFTokenAuthMiddleware(object):
         if request.method == 'GET' and request.headers.get('Authorization', '').startswith('Token'):
             drf_request = Request(request)
             try:
-                user_auth = TokenAuthentication().authenticate(drf_request)
+                user_auth = OCSTokenAuthentication().authenticate(drf_request)
                 # Set the request.user field if we successfully authenticate with TokenAuthentication
                 if user_auth:
                     request.user = user_auth[0]

--- a/archive/settings.py
+++ b/archive/settings.py
@@ -229,7 +229,7 @@ OCS_AUTHENTICATION = {
 }
 
 # Anonymous requests with offsets > this will be blocked - to stop the bots
-MAX_UNAUTHENTICATED_OFFSET = os.getenv('MAX_UNAUTHENTICATED_OFFSET', 1000)
+MAX_UNAUTHENTICATED_OFFSET = os.getenv('MAX_UNAUTHENTICATED_OFFSET', 10000)
 # Anonymous requests with limits > this will be blocked - to slow the bots
 MAX_UNAUTHENTICATED_LIMIT = os.getenv('MAX_UNAUTHENTICATED_LIMIT', 100)
 

--- a/archive/settings.py
+++ b/archive/settings.py
@@ -57,8 +57,11 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'archive.authentication.middleware.DRFTokenAuthMiddleware',
+    'archive.authentication.middleware.RemoteUserLogMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'archive.authentication.middleware.LimitAnonymousAccessMiddleware',
 ]
 
 AUTHENTICATION_BACKENDS = [
@@ -224,6 +227,11 @@ OCS_AUTHENTICATION = {
     'OAUTH_SERVER_KEY': os.getenv('OAUTH_SERVER_KEY', ''),
     'REQUESTS_TIMEOUT_SECONDS': 60
 }
+
+# Anonymous requests with offsets > this will be blocked - to stop the bots
+MAX_UNAUTHENTICATED_OFFSET = os.getenv('MAX_UNAUTHENTICATED_OFFSET', 1000)
+# Anonymous requests with limits > this will be blocked - to slow the bots
+MAX_UNAUTHENTICATED_LIMIT = os.getenv('MAX_UNAUTHENTICATED_LIMIT', 100)
 
 CORS_ORIGIN_ALLOW_ALL = True
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,3 +1,8 @@
+# Access log format. %({remote_user}e)s reads the WSGI environ's REMOTE_USER,
+# which RemoteUserLogMiddleware sets to the authenticated username (or 'anonymous').
+access_log_format = '%(h)s %(l)s %({remote_user}e)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+
+
 def post_worker_init(worker):
     # Warm botocore's S3 service model cache before this worker accepts requests.
     # This runs after gevent's monkey.patch_all(), so the SSL context created here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "science-archive"
-version = "2.7.4"
+version = "2.7.5"
 description = ""
 authors = ["Jashandeep Sohi <jsohi@lco.global>"]
 readme = "README.md"


### PR DESCRIPTION
…ed users

The same middleware we have in the obs portal now for setting the request.user for API requests in middle, blocking the limit/offset if its too large for unauthenticated requests, and a new middleware for setting the user to request.META[] environment variable so gunicorn can use it in the access log. The access log format is otherwise unchanged from the default, just adding in the username before the timestamp.