### PR TITLE
Feature/id filter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,7 @@ jobs:
       uses: coverallsapp/github-action@v2.3.7
       with:
         parallel: true
+        fail-on-error: false
         coverage-reporter-version: v0.6.13
   finish:
     runs-on: ubuntu-latest
@@ -75,6 +76,7 @@ jobs:
         uses: coverallsapp/github-action@v2.3.7
         with:
           parallel-finished: true
+          fail-on-error: false
           coverage-reporter-version: v0.6.13
 
   build_and_publish_image:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,9 @@ jobs:
         pip install -r .poetry-version
         pip install -r <(poetry export --with dev)
     - name: Run tests
-      run: poetry run coverage run manage.py test --settings=test_settings
+      run: |
+        poetry run coverage run manage.py test --settings=test_settings
+        poetry run coverage xml
       env:
         DB_USER: postgres
         DB_PASS: postgres
@@ -61,17 +63,19 @@ jobs:
         DB_HOST_READER: 127.0.0.1
         DB_PORT: 5432
     - name: Generate and send coveralls report
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@v2.3.7
       with:
         parallel: true
+        coverage-reporter-version: v0.6.13
   finish:
     runs-on: ubuntu-latest
     needs: run_tests
     steps:
       - name: Close parallel build
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.7
         with:
           parallel-finished: true
+          coverage-reporter-version: v0.6.13
 
   build_and_publish_image:
     # Only run this job if the run_tests job has succeeded, and if

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.7.6
+2026-07-23
+Add `id__gt` filter to efficiently query for newly added frames
+
 2.7.5
 2026-07-20
 Add in unauthenticated limit/offset limits to GET API requests

--- a/archive/frames/filters.py
+++ b/archive/frames/filters.py
@@ -36,7 +36,7 @@ class FrameFilter(django_filters.FilterSet):
     BLKUID = django_filters.NumberFilter(field_name='observation_id', lookup_expr='exact')
     REQNUM = django_filters.NumberFilter(field_name='request_id', lookup_expr='exact')
     RLEVEL = django_filters.NumberFilter(field_name='reduction_level', lookup_expr='exact')
-    id_gt = django_filters.NumberFilter(field_name='id', lookup_expr='gt')
+    id__gt = django_filters.NumberFilter(field_name='id', lookup_expr='gt')
     covers = django_filters.CharFilter(method='covers_filter')
     submitter = django_filters.CharFilter(method='submitter_filter')
     exclude_OBSTYPE = django_filters.MultipleChoiceFilter(

--- a/archive/frames/filters.py
+++ b/archive/frames/filters.py
@@ -36,6 +36,7 @@ class FrameFilter(django_filters.FilterSet):
     BLKUID = django_filters.NumberFilter(field_name='observation_id', lookup_expr='exact')
     REQNUM = django_filters.NumberFilter(field_name='request_id', lookup_expr='exact')
     RLEVEL = django_filters.NumberFilter(field_name='reduction_level', lookup_expr='exact')
+    id_gt = django_filters.NumberFilter(field_name='id', lookup_expr='gt')
     covers = django_filters.CharFilter(method='covers_filter')
     submitter = django_filters.CharFilter(method='submitter_filter')
     exclude_OBSTYPE = django_filters.MultipleChoiceFilter(

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -341,6 +341,19 @@ class TestQueryFiltering(ReplicationTestCase):
         response = self.client.get(reverse('frame-list') + '?EXPTIME=900')
         self.assertNotContains(response, frame.basename)
 
+    def test_id_gt(self):
+        # frame2 is created after frame1, so it has a higher auto-increment id
+        frame1 = PublicFrameFactory()
+        frame2 = PublicFrameFactory()
+        response = self.client.get(reverse('frame-list') + '?id_gt={}'.format(frame1.id))
+        # id_gt is strictly greater than, so the boundary frame itself is excluded
+        self.assertNotContains(response, frame1.basename)
+        self.assertContains(response, frame2.basename)
+        # Nothing has an id greater than the last-created frame
+        response = self.client.get(reverse('frame-list') + '?id_gt={}'.format(frame2.id))
+        self.assertNotContains(response, frame1.basename)
+        self.assertNotContains(response, frame2.basename)
+
     @responses.activate
     def test_filters_public(self):
         user = User.objects.create(username='frodo', password='theone')

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -345,12 +345,12 @@ class TestQueryFiltering(ReplicationTestCase):
         # frame2 is created after frame1, so it has a higher auto-increment id
         frame1 = PublicFrameFactory()
         frame2 = PublicFrameFactory()
-        response = self.client.get(reverse('frame-list') + '?id_gt={}'.format(frame1.id))
-        # id_gt is strictly greater than, so the boundary frame itself is excluded
+        response = self.client.get(reverse('frame-list') + '?id__gt={}'.format(frame1.id))
+        # id__gt is strictly greater than, so the boundary frame itself is excluded
         self.assertNotContains(response, frame1.basename)
         self.assertContains(response, frame2.basename)
         # Nothing has an id greater than the last-created frame
-        response = self.client.get(reverse('frame-list') + '?id_gt={}'.format(frame2.id))
+        response = self.client.get(reverse('frame-list') + '?id__gt={}'.format(frame2.id))
         self.assertNotContains(response, frame1.basename)
         self.assertNotContains(response, frame2.basename)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "science-archive"
-version = "2.7.5"
+version = "2.7.6"
 description = ""
 authors = ["Jashandeep Sohi <jsohi@lco.global>"]
 readme = "README.md"


### PR DESCRIPTION
Simple change adding `id__gt` filter to help querying the latest frames added to the archive efficiently. Frame ID ordering isn't guaranteed to be exactly in order within ~5-10s, so when using this to get the latest frames, the cadence of querying should be >10s, and the `id__gt` should be from one query in the past to avoid ever missing frames.