### PR TITLE
Another round of anti-bot measures

### DIFF
--- a/archive/authentication/middleware.py
+++ b/archive/authentication/middleware.py
@@ -60,7 +60,7 @@ class DRFTokenAuthMiddleware(object):
 
     def __call__(self, request):
         # Check if this is a Token Auth request based on the Auth header having `Token` in it.
-        if request.method == 'GET' and request.headers.get('Authorization', '').startswith('Token'):
+        if request.headers.get('Authorization', '').startswith('Token'):
             drf_request = Request(request)
             try:
                 user_auth = OCSTokenAuthentication().authenticate(drf_request)

--- a/archive/authentication/tests.py
+++ b/archive/authentication/tests.py
@@ -1,7 +1,11 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory
 from unittest.mock import patch
+from archive.authentication.middleware import DRFTokenAuthMiddleware
 from archive.authentication.models import Profile
+from rest_framework.authtoken.models import Token
 from archive.frames.tests.factories import FrameFactory
 from archive.test_helpers import ReplicationTestCase
 from archive.frames.utils import aggregate_frames_sql, set_cached_frames_aggregates
@@ -14,7 +18,45 @@ import json
 
 
 
-class TestRevokeTokenAPI(APITestCase):
+class TestDRFTokenAuthMiddleware(ReplicationTestCase):
+    """
+    Verify that the middleware properly validates for an authenticated users
+    """
+    def setUp(self):
+        self.user = User.objects.create(username='ingest')
+        self.token, _ = Token.objects.get_or_create(user=self.user)
+        self.factory = RequestFactory()
+
+    def is_authenticated_at_middleware_time(self, method, **headers):
+        request = getattr(self.factory, method)('/frames/', **headers)
+        request.user = AnonymousUser()
+        seen = {}
+
+        def get_response(request):
+            seen['authenticated'] = request.user.is_authenticated
+            return HttpResponse()
+
+        DRFTokenAuthMiddleware(get_response)(request)
+        return seen['authenticated']
+
+    def test_token_is_resolved_for_reads(self):
+        authorization = f'Token {self.token.key}'
+        self.assertTrue(self.is_authenticated_at_middleware_time('get', HTTP_AUTHORIZATION=authorization))
+
+    def test_token_is_resolved_for_writes(self):
+        authorization = f'Token {self.token.key}'
+        for method in ('post', 'put', 'patch', 'delete'):
+            with self.subTest(method=method):
+                self.assertTrue(self.is_authenticated_at_middleware_time(method, HTTP_AUTHORIZATION=authorization))
+
+    def test_request_without_a_token_stays_anonymous(self):
+        self.assertFalse(self.is_authenticated_at_middleware_time('post'))
+
+    def test_invalid_token_stays_anonymous(self):
+        self.assertFalse(self.is_authenticated_at_middleware_time('post', HTTP_AUTHORIZATION='Token notarealtoken'))
+
+
+class TestRevokeTokenAPI(ReplicationTestCase, APITestCase):
     def setUp(self) -> None:
         super(TestRevokeTokenAPI, self).setUp()
         self.user = User.objects.create(username='test_revoke_token_user')

--- a/archive/dbrouters.py
+++ b/archive/dbrouters.py
@@ -1,6 +1,34 @@
-from datetime import timedelta, datetime, timezone
+from contextvars import ContextVar
 
-from archive.frames.models import Frame, Version
+# Set per request by ReadRoutingMiddleware - keeps track of if an authenticated user
+# was found in the middleware. Used in the Database reader routing.
+authenticated_request = ContextVar('authenticated_request', default=False)
+
+# Logging in writes a session and reads it back, along with the user row, on the very next
+# request - too soon to rely on replication.
+AUTHENTICATION_APPS = frozenset(['sessions', 'auth'])
+
+
+class ReadRoutingMiddleware:
+    """
+    Record whether the request is authenticated so that DBClusterRouter can route
+    unauthenticated reads to the replica DB
+
+    Database routers aren't given the request, so the decision has to be passed to the router
+    out of band. This must run after AuthenticationMiddleware and DRFTokenAuthMiddleware,
+    which are what populate request.user.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # request.user is missing if this middleware is ever placed before the auth middleware
+        user = getattr(request, 'user', None)
+        token = authenticated_request.set(user is not None and user.is_authenticated)
+        try:
+            return self.get_response(request)
+        finally:
+            authenticated_request.reset(token)
 
 
 class DBClusterRouter:
@@ -9,27 +37,13 @@ class DBClusterRouter:
     """
     def db_for_read(self, model, **hints):
         """
-        Reads for the archive frames models go to the reader endpoint.
-
-        Reads for certain frames models are directed to the writer endpoint if the
-        instance was recently created in order to prevent a race condition. This
-        could happen if, for example, data that has been committed has not been
-        replicated fast enough. This is an issue specifically in the frame
-        creation view.
+        Reads for authenticated requests go to the writer endpoint, and reads for
+        unauthenticated ones go to the reader endpoint
         """
-        new_instance_delay_minutes = 10
-        new_instance_delay_models = (Frame, Version,)
-        instance = hints.get('instance')
-        created = getattr(instance, 'created', None)
+        if authenticated_request.get() or model._meta.app_label in AUTHENTICATION_APPS:
+            return 'default'
 
-        if isinstance(instance, new_instance_delay_models) and created is not None:
-            if created > datetime.now(timezone.utc) - timedelta(minutes=new_instance_delay_minutes):
-                return 'default'
-
-        if 'archive.frames.models' in str(model):
-            return 'replica'
-
-        return 'default'
+        return 'replica'
 
     def db_for_write(self, model, **hints):
         """

--- a/archive/frames/filters.py
+++ b/archive/frames/filters.py
@@ -1,13 +1,48 @@
 from archive.frames.models import Frame, Thumbnail
+from archive.frames.pagination import is_small_query
 from archive.frames.utils import get_configuration_type_tuples
 from archive.settings import SCIENCE_CONFIGURATION_TYPES
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.gis.geos.error import GEOSException
 from rest_framework.exceptions import ValidationError
+from rest_framework.filters import OrderingFilter
 import datetime
 from django.conf import settings
 from django_filters import rest_framework as django_filters
 from anyascii import anyascii
+
+# Ordering by any other field requires sorting the entire result set, so it is only
+# allowed on queries that is_small_query() determines are sufficiently bounded.
+SAFE_ORDERING_FIELDS = frozenset(['id', 'observation_date'])
+
+
+class SafeOrderingFilter(OrderingFilter):
+    """
+    Restricts ordering to indexed fields unless the query is bounded enough that
+    sorting on an arbitrary field is cheap.
+    """
+    ordering_description = (
+        'Which field to use when ordering the results. Ordering by a field other than '
+        '{} is only allowed on queries constrained by an indexed field or a short time range.'.format(
+            ' or '.join(sorted(SAFE_ORDERING_FIELDS))
+        )
+    )
+
+    def remove_invalid_fields(self, queryset, fields, view, request):
+        valid_fields = super().remove_invalid_fields(queryset, fields, view, request)
+        small_query, _ = is_small_query(request)
+        if small_query:
+            return valid_fields
+        rejected_fields = [field for field in valid_fields if field.lstrip('-') not in SAFE_ORDERING_FIELDS]
+        if rejected_fields:
+            raise ValidationError(
+                'Ordering by {} requires a more constrained query. Either narrow the search '
+                '(for example with request_id, observation_id, basename_exact, or a start/end '
+                'range of a week or less) or order by one of: {}.'.format(
+                    ', '.join(rejected_fields), ', '.join(sorted(SAFE_ORDERING_FIELDS))
+                )
+            )
+        return valid_fields
 
 
 class FrameFilter(django_filters.FilterSet):

--- a/archive/frames/pagination.py
+++ b/archive/frames/pagination.py
@@ -9,6 +9,42 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def is_small_query(request):
+    """
+    Determine whether a request is constrained enough by indexed or otherwise bounded
+    filters that a real count (and an arbitrary sort) is safe to attempt.
+
+    Returns a (small_query, force_count) tuple.
+    """
+    query_params = dict(request.query_params)
+    # If these indexed fields are in the query params, query should be small and bounded so allow full count
+    # Also have a fallback 'force_count' param to force it to attempt the full count
+    if 'force_count' in query_params and request.user.is_authenticated:
+        return True, True
+    # /versions/?md5= queries need the accurate count for shipping data in
+    elif request.path == '/versions/' and 'md5' in query_params:
+        return True, True
+    # /thumbnails/ queries with indexed fields can have the full count
+    elif request.path == '/thumbnails/' and ('frame_basename' in query_params or 'observation_id' in query_params or 'request_id' in query_params):
+        return True, False
+    elif request.path == '/frames/':
+        # /frames/ queries with indexed fields, or with a small timerange and other common fields.
+        if 'request_id' in query_params or 'observation_id' in query_params or 'basename_exact' in query_params:
+            return True, False
+        elif 'start' in query_params and 'end' in query_params:
+            end = dateparse.parse_datetime(request.query_params.get('end')).replace(tzinfo=None)
+            start = dateparse.parse_datetime(request.query_params.get('start')).replace(tzinfo=None)
+            timespan = end - start
+            # Allow 1 week of querys with no other params
+            if timespan <= timedelta(days=7):
+                return True, False
+            # Or up to 2 months of querys with some other bounding params
+            elif timespan <= timedelta(weeks=9) and any(field in query_params for field in ['proposal_id', 'target_name_exact']):
+                return True, False
+
+    return False, False
+
+
 class CustomCursorPagination(CursorPagination):
     page_size_query_param='limit'
     page_size = settings.PAGINATION_DEFAULT_LIMIT
@@ -38,12 +74,15 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
         - If any other exception occured fall back to no count (large number returned).
         """
         self.count_estimated = False
+        # Whichever endpoint the router sent this query to is the one that has to be
+        # timed out and estimated against - see archive.dbrouters
+        db = queryset.db
         # Only attempt to get the real count if we have already determined this is a "small" query
         if self.small_query:
             # Limit to 5000 ms if force_count is used, otherwise 1500 ms
             timeout = '5000' if self.force_count else '1500'
             try:
-                with transaction.atomic(using='replica'), connections['replica'].cursor() as cursor:
+                with transaction.atomic(using=db), connections[db].cursor() as cursor:
                     cursor.execute(f'SET LOCAL statement_timeout TO {timeout};')
                     return super().get_count(queryset)
             except (OperationalError, InternalError):
@@ -53,7 +92,7 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
         if not queryset.query.where:
             logger.warning("Estimating the count using postgres stats table")
             try:
-                with transaction.atomic(using='replica'), connections['replica'].cursor() as cursor:
+                with transaction.atomic(using=db), connections[db].cursor() as cursor:
                     # Obtain estimated values (only valid with PostgreSQL)
                     cursor.execute(
                         "SELECT reltuples FROM pg_class WHERE relname = %s",
@@ -66,7 +105,7 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
         else:
             logger.warning("Estimating the count using the postgres query planner")
             try:
-                with transaction.atomic(using='replica'), connections['replica'].cursor() as cursor:
+                with transaction.atomic(using=db), connections[db].cursor() as cursor:
                     sql = cursor.mogrify(*queryset.query.sql_with_params())
                     cursor.execute(
                         "SELECT count_estimate(%s);",
@@ -81,34 +120,7 @@ class LimitedLimitOffsetPagination(LimitOffsetPagination):
 
     def paginate_queryset(self, queryset, request, view=None):
         # If certain conditions are met, this is a "small" query and we can attempt a real count
-        query_params = dict(request.query_params)
-        # If these indexed fields are in the query params, query should be small and bounded so allow full count
-        # Also have a fallback 'force_count' param to force it to attempt the full count
-        if 'force_count' in query_params and request.user.is_authenticated:
-            self.force_count = True
-            self.small_query = True
-        # /versions/?md5= queries need the accurate count for shipping data in
-        elif request.path == '/versions/' and 'md5' in query_params:
-            self.force_count = True
-            self.small_query = True
-        # /thumbnails/ queries with indexed fields can have the full count
-        elif request.path == '/thumbnails/' and ('frame_basename' in query_params or 'observation_id' in query_params or 'request_id' in query_params):
-            self.small_query = True
-        elif request.path == '/frames/':
-            # /frames/ queries with indexed fields, or with a small timerange and other common fields.
-            if 'request_id' in query_params or 'observation_id' in query_params or 'basename_exact' in query_params:
-                self.small_query = True
-            elif 'start' in query_params and 'end' in query_params:
-                timespan = dateparse.parse_datetime(request.query_params.get('end')) - dateparse.parse_datetime(request.query_params.get('start'))
-                # Allow 1 week of querys with no other params
-                if timespan <= timedelta(days=7):
-                    self.small_query = True
-                # Or up to 2 months of querys with some other bounding params
-                elif timespan <= timedelta(weeks=9) and any(field in query_params for field in ['proposal_id', 'target_name_exact']):
-                    self.small_query = True
-        else:
-            self.force_count = False
-            self.small_query = False
+        self.small_query, self.force_count = is_small_query(request)
         result = super().paginate_queryset(queryset, request, view)
         # If the count was estimated and we have an offset, then correct the results!
         # This is needed because the base code returns an empty list if offset > count

--- a/archive/frames/tests/test_views.py
+++ b/archive/frames/tests/test_views.py
@@ -483,6 +483,78 @@ class TestQueryFiltering(ReplicationTestCase):
         response = self.client.get(reverse('frame-list') + '?RLEVEL=11')
         self.assertNotContains(response, frame.basename)
 
+    def test_start_end_with_mixed_naive_and_aware_bounds(self):
+        frame = PublicFrameFactory(observation_date=datetime.datetime(2011, 2, 1, tzinfo=datetime.timezone.utc))
+        response = self.client.get(reverse('frame-list') + '?start=2011-01-01&end=2011-03-01T00:00:00Z')
+        self.assertContains(response, frame.basename)
+
+
+class TestFrameOrdering(ReplicationTestCase):
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser(username='admin', email='a@a.com', password='password')
+        self.admin_user.backend = settings.AUTHENTICATION_BACKENDS[0]
+        self.frames = [
+            PublicFrameFactory(exposure_time=exposure_time, request_id=42,
+                               observation_date=datetime.datetime(2011, 2, day, tzinfo=datetime.timezone.utc))
+            for day, exposure_time in enumerate([30.0, 10.0, 20.0], start=1)
+        ]
+
+    def test_safe_ordering_field_allowed_on_unbounded_query(self):
+        for ordering in ('id', '-id', 'observation_date', '-observation_date'):
+            response = self.client.get(reverse('frame-list'), {'ordering': ordering})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unsafe_ordering_field_rejected_on_unbounded_query(self):
+        response = self.client.get(reverse('frame-list'), {'ordering': 'exposure_time'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertContains(response, 'requires a more constrained query', status_code=400)
+
+    def test_descending_unsafe_ordering_field_rejected(self):
+        response = self.client.get(reverse('frame-list'), {'ordering': '-exposure_time'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unsafe_ordering_field_rejected_alongside_safe_one(self):
+        response = self.client.get(reverse('frame-list'), {'ordering': 'observation_date,exposure_time'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unknown_ordering_field_still_falls_back_to_default(self):
+        response = self.client.get(reverse('frame-list'), {'ordering': 'not_a_field'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unsafe_ordering_field_allowed_on_indexed_query(self):
+        response = self.client.get(reverse('frame-list'), {'request_id': 42, 'ordering': 'exposure_time'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [frame['exposure_time'] for frame in response.json()['results']], [10.0, 20.0, 30.0]
+        )
+
+    def test_unsafe_ordering_field_allowed_on_short_timerange_query(self):
+        response = self.client.get(
+            reverse('frame-list'), {'start': '2011-02-01', 'end': '2011-02-04', 'ordering': 'exposure_time'}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unsafe_ordering_field_rejected_on_long_timerange_query(self):
+        response = self.client.get(
+            reverse('frame-list'), {'start': '2011-01-01', 'end': '2011-06-01', 'ordering': 'exposure_time'}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unsafe_ordering_field_allowed_with_force_count(self):
+        self.client.force_login(self.admin_user)
+        response = self.client.get(reverse('frame-list'), {'force_count': True, 'ordering': 'exposure_time'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unsafe_ordering_field_rejected_for_anonymous_force_count(self):
+        response = self.client.get(reverse('frame-list'), {'force_count': True, 'ordering': 'exposure_time'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unsafe_ordering_field_rejected_with_cursor_pagination(self):
+        response = self.client.get(
+            reverse('frame-list'), {'pagination_style': 'cursor', 'ordering': 'exposure_time'}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestZipDownload(ReplicationTestCase):
     def setUp(self):

--- a/archive/frames/views.py
+++ b/archive/frames/views.py
@@ -1,4 +1,4 @@
-from archive.schema import ScienceArchiveSchema
+from archive.schema import DocumentedDjangoFilterBackend, ScienceArchiveSchema
 from archive.frames.exceptions import FunpackError
 from archive.frames.models import Frame, Thumbnail, Version
 from archive.frames.serializers import (
@@ -11,17 +11,16 @@ from archive.frames.utils import (
 
 )
 from archive.frames.permissions import AdminOrReadOnly
-from archive.frames.filters import FrameFilter, ThumbnailFilter
+from archive.frames.filters import FrameFilter, SafeOrderingFilter, ThumbnailFilter
 
 from archive.doc_examples import EXAMPLE_RESPONSES, QUERY_PARAMETERS
 from archive.frames.pagination import LimitedLimitOffsetPagination, CustomCursorPagination
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAdminUser
-from rest_framework import status, filters, viewsets
+from rest_framework import status, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import APIException
-from django_filters.rest_framework import DjangoFilterBackend
 from django.http import HttpResponse
 from django.db.models import Q, Prefetch, Count, Exists, OuterRef
 from django.views.decorators.clickjacking import xframe_options_exempt
@@ -73,8 +72,8 @@ class FrameViewSet(SelectablePaginationMixin, viewsets.ModelViewSet):
     schema = ScienceArchiveSchema(tags=['Frames'])
     serializer_class = FrameSerializer
     filter_backends = (
-        DjangoFilterBackend,
-        filters.OrderingFilter,
+        DocumentedDjangoFilterBackend,
+        SafeOrderingFilter,
     )
     filterset_class = FrameFilter
     ordering_fields = ('id', 'basename', 'observation_date', 'primary_optical_element', 'configuration_type',
@@ -482,7 +481,7 @@ class ThumbnailViewSet(viewsets.ModelViewSet):
     serializer_class = ThumbnailSerializer
     permission_classes = (AdminOrReadOnly,)
     filter_backends = (
-        DjangoFilterBackend,
+        DocumentedDjangoFilterBackend,
     )
     filterset_class = ThumbnailFilter
 
@@ -568,7 +567,7 @@ class VersionViewSet(viewsets.ReadOnlyModelViewSet):
     # data, as the available endpoint on this admin viewset is used to check whether a version
     # already exists before attempting to ingest a new version.
     queryset = Version.objects.using('default').all()
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (DocumentedDjangoFilterBackend,)
     filterset_fields = ('md5',)
 
 

--- a/archive/schema.py
+++ b/archive/schema.py
@@ -4,12 +4,53 @@ from rest_framework.schemas.utils import is_list_view
 from setuptools_scm import get_version
 from setuptools_scm.version import ScmVersion
 from django.conf import settings
+from django_filters.rest_framework import DjangoFilterBackend
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 def version_scheme(version: ScmVersion) -> str:
     """Simply return the string representation of the version object tag, which is the latest git tag.
     setuptools_scm does not provide a simple semantic versioning format without trying to guess the next release, or adding some metadata to the version.
     """
     return str(version.tag)
+
+
+class DocumentedDjangoFilterBackend(DjangoFilterBackend):
+    """
+    django-filter dropped DRF schema support in 25.1 (DRF's own schema generation is
+    deprecated in favour of drf-spectacular), but DRF's AutoSchema still calls
+    get_schema_operation_parameters() on every filter backend, so schema generation raises
+    an AttributeError without this.
+    """
+    def get_schema_operation_parameters(self, view):
+        # Views with no filters have nothing to document, so ignore them
+        if not getattr(view, 'filterset_class', None) and not getattr(view, 'filterset_fields', None):
+            return []
+
+        try:
+            queryset = view.get_queryset()
+        except Exception:
+            queryset = None
+            logger.warning(f'{view.__class__} is not compatible with schema generation')
+
+        filterset_class = self.get_filterset_class(view, queryset)
+        if not filterset_class:
+            return []
+
+        return [
+            {
+                'name': field_name,
+                'required': field.extra['required'],
+                'in': 'query',
+                'description': field.label if field.label is not None else field_name,
+                'schema': {
+                    'type': 'string',
+                },
+            }
+            for field_name, field in filterset_class.base_filters.items()
+        ]
 
 
 class ScienceArchiveSchemaGenerator(SchemaGenerator):
@@ -77,31 +118,6 @@ class ScienceArchiveSchema(AutoSchema):
 
         return super().get_filter_parameters(path, method)
 
-    # The following class methods are based off a change merged to master in the DRF repository
-    # that allows for the specification of separate request and response serializers for view introspection.
-    # See https://github.com/encode/django-rest-framework/pull/7424
-
-    # These overrides can be removed once a new release containing these changes is available.
-    # TODO: Remove these when the next version of DRF is released
-
-    def get_components(self, path, method):
-        request_serializer = self.get_request_serializer(path, method)
-        response_serializer = self.get_response_serializer(path, method)
-
-        components = {}
-
-        if isinstance(request_serializer, serializers.Serializer):
-            component_name = self.get_component_name(request_serializer)
-            content = self.map_serializer(request_serializer)
-            components.setdefault(component_name, content)
-
-        if isinstance(response_serializer, serializers.Serializer):
-            component_name = self.get_component_name(response_serializer)
-            content = self.map_serializer(response_serializer)
-            components.setdefault(component_name, content)
-
-        return components
-
     def get_request_serializer(self, path, method):
         view = self.view
 
@@ -125,64 +141,3 @@ class ScienceArchiveSchema(AutoSchema):
                 return view.get_serializer()
         else:
             return view.get_response_serializer()
-
-    def get_request_body(self, path, method):
-        if method not in ('PUT', 'PATCH', 'POST'):
-            return {}
-
-        self.request_media_types = self.map_parsers(path, method)
-
-        serializer = self.get_request_serializer(path, method)
-
-        if not isinstance(serializer, serializers.Serializer):
-            item_schema = {}
-        else:
-            item_schema = self._get_reference(serializer)
-
-        return {
-            'content': {
-                ct: {'schema': item_schema}
-                for ct in self.request_media_types
-            }
-        }
-
-    def get_responses(self, path, method):
-        if method == 'DELETE':
-            return {
-                '204': {
-                    'description': ''
-                }
-            }
-
-        self.response_media_types = self.map_renderers(path, method)
-
-        serializer = self.get_response_serializer(path, method)
-
-        if not isinstance(serializer, serializers.Serializer):
-            item_schema = {}
-        else:
-            item_schema = self._get_reference(serializer)
-
-        if is_list_view(path, method, self.view):
-            response_schema = {
-                'type': 'array',
-                'items': item_schema,
-            }
-            paginator = self.get_paginator()
-            if paginator:
-                response_schema = paginator.get_paginated_response_schema(response_schema)
-        else:
-            response_schema = item_schema
-        status_code = '201' if method == 'POST' else '200'
-        return {
-            status_code: {
-                'content': {
-                    ct: {'schema': response_schema}
-                    for ct in self.response_media_types
-                },
-                # description is a mandatory property,
-                # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject
-                # TODO: put something meaningful into it
-                'description': ""
-            }
-        }

--- a/archive/settings.py
+++ b/archive/settings.py
@@ -58,6 +58,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'archive.authentication.middleware.DRFTokenAuthMiddleware',
+    'archive.dbrouters.ReadRoutingMiddleware',
     'archive.authentication.middleware.RemoteUserLogMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -209,7 +210,7 @@ REST_FRAMEWORK = {
         'user': '50000/day',
     },
     'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
+        'archive.schema.DocumentedDjangoFilterBackend',
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',

--- a/archive/test_dbrouters.py
+++ b/archive/test_dbrouters.py
@@ -1,0 +1,96 @@
+from archive.dbrouters import ReadRoutingMiddleware, authenticated_request
+from archive.frames.models import Frame
+from archive.test_helpers import ReplicationTestCase
+from django.contrib.auth.models import AnonymousUser, User
+from django.contrib.sessions.models import Session
+from django.db import router
+from django.http import HttpResponse
+from django.test import RequestFactory
+from rest_framework.authtoken.models import Token
+
+
+class TestReadRouting(ReplicationTestCase):
+    """
+    Reads for anonymous requests go to the reader endpoint so that bot traffic has less
+    impact on real users, who are served by the writer.
+    """
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create(username='frodo', password='theone')
+
+    def route(self, request):
+        """Run a request through the middleware and report where its reads would go"""
+        databases = {}
+
+        def get_response(request):
+            databases['frame'] = Frame.objects.all().db
+            databases['user'] = User.objects.all().db
+            return HttpResponse()
+
+        ReadRoutingMiddleware(get_response)(request)
+        return databases
+
+    def test_anonymous_request_reads_from_the_replica(self):
+        request = self.factory.get('/frames/')
+        request.user = AnonymousUser()
+        self.assertEqual(self.route(request), {'frame': 'replica', 'user': 'default'})
+
+    def test_authenticated_request_reads_from_the_writer(self):
+        request = self.factory.get('/frames/')
+        request.user = self.user
+        self.assertEqual(self.route(request), {'frame': 'default', 'user': 'default'})
+
+    def test_request_without_a_user_reads_from_the_replica(self):
+        self.assertEqual(self.route(self.factory.get('/frames/'))['frame'], 'replica')
+
+    def test_writes_always_go_to_the_writer(self):
+        request = self.factory.get('/frames/')
+        request.user = AnonymousUser()
+
+        def get_response(request):
+            self.assertEqual(router.db_for_write(Frame), 'default')
+            return HttpResponse()
+
+        ReadRoutingMiddleware(get_response)(request)
+
+    def test_routing_does_not_leak_between_requests(self):
+        authenticated = self.factory.get('/frames/')
+        authenticated.user = self.user
+        self.route(authenticated)
+
+        self.assertFalse(authenticated_request.get())
+        anonymous = self.factory.get('/frames/')
+        anonymous.user = AnonymousUser()
+        self.assertEqual(self.route(anonymous)['frame'], 'replica')
+
+    def test_routing_is_reset_when_the_view_raises(self):
+        request = self.factory.get('/frames/')
+        request.user = self.user
+
+        def get_response(request):
+            raise ValueError('view exploded')
+
+        with self.assertRaises(ValueError):
+            ReadRoutingMiddleware(get_response)(request)
+
+        self.assertFalse(authenticated_request.get())
+
+    def test_login_models_always_use_the_writer(self):
+        request = self.factory.get('/frames/')
+        request.user = AnonymousUser()
+
+        def get_response(request):
+            # A session and its user are read back on the request right after logging in,
+            # which is sooner than they can be expected to have replicated
+            for model in (Session, User):
+                self.assertEqual(router.db_for_read(model), 'default', model.__name__)
+            # API tokens only change when a user regenerates one by hand, so the reader is
+            # current enough for them
+            self.assertEqual(router.db_for_read(Token), 'replica')
+            return HttpResponse()
+
+        ReadRoutingMiddleware(get_response)(request)
+
+    def test_reads_outside_the_request_cycle_use_the_replica(self):
+        # Management commands and workers keep reading from the reader as they always have
+        self.assertEqual(Frame.objects.all().db, 'replica')

--- a/archive/test_schema.py
+++ b/archive/test_schema.py
@@ -1,0 +1,32 @@
+from archive.test_helpers import ReplicationTestCase
+from django.urls import reverse
+from rest_framework import status
+
+import json
+
+
+class TestOpenApiSchema(ReplicationTestCase):
+    """
+    Test that the OpenAPI schema generation works
+    """
+    def get_schema(self):
+        response = self.client.get(reverse('openapi-schema'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return json.loads(response.content)
+
+    def test_schema_documents_every_endpoint(self):
+        schema = self.get_schema()
+        for path in ('/frames/', '/frames/{id}/', '/frames/aggregate/', '/frames/zip/',
+                     '/thumbnails/', '/versions/', '/profile/'):
+            self.assertIn(path, schema['paths'])
+
+    def test_schema_documents_frame_filters(self):
+        parameters = {p['name'] for p in self.get_schema()['paths']['/frames/']['get']['parameters']}
+        # Filters come from the filterset, pagination and ordering from their backends
+        for parameter in ('start', 'end', 'covers', 'exclude_calibrations', 'limit', 'offset', 'ordering'):
+            self.assertIn(parameter, parameters)
+
+    def test_schema_documents_the_ordering_restriction(self):
+        parameters = self.get_schema()['paths']['/frames/']['get']['parameters']
+        ordering = next(p for p in parameters if p['name'] == 'ordering')
+        self.assertIn('observation_date', ordering['description'])


### PR DESCRIPTION
3 fixes, 2 of which are to address recent bot attacks

1. Fix schema generation for /openapi/ endpoint - it was broken from the latest dependency updating since latest django-filters dropped support for DRF schema generation. These are the changes in schema.py to essentially add that back but in the long run we should migrate out of DRF schema generation since its no longer supported

2. Route unauthenticated access to the replica DB. This involves another middleware to mark in thread-local storage if the user is authenticated so that the database router can read that and determine whether to route to the replica or writer. Simplified the logic to all authenticated users go to write, all unauthenticated go to reader, and session/auth go to writer since those are created and checked immediately.

3. Block sorting by any fields other than id/observation_date unless the request is sufficiently filtered to be "small". The pagination logic for the exact count was re-used here as the definition of a "small" enough query.

New unit tests for this stuff - the middleware/routing stuff wasn't really tested before so these lock down the behavior. 